### PR TITLE
Trigger rebuild now that qwt is available

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ about:
   home: http://qwtpolar.sourceforge.net/ 
   license: Qwt License, Version 1.0
   license_file: COPYING
-  summary: Polar coordinate system plots for Qwt
+  summary: 'Polar coordinate system plots for Qwt'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Initial build failed because of dependency on `qwt` that was being rendered simultaneously. Now that `qwt` is available in `conda-forge` channels, retry building `qwtpolar`.
